### PR TITLE
invoice: Fix NPE when attributes is null in CreateInvoiceModel

### DIFF
--- a/budgeteer-persistence/src/main/java/de/adesso/budgeteer/persistence/invoice/InvoiceEntityAdapter.java
+++ b/budgeteer-persistence/src/main/java/de/adesso/budgeteer/persistence/invoice/InvoiceEntityAdapter.java
@@ -9,9 +9,7 @@ import de.adesso.budgeteer.persistence.contract.ContractRepository;
 import de.adesso.budgeteer.persistence.project.ProjectRepository;
 import java.sql.Date;
 import java.time.LocalDate;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -71,16 +69,22 @@ public class InvoiceEntityAdapter
     invoiceEntity.setMonth(command.getYearMonth().getMonthValue());
     invoiceEntity.setDate(
         Date.valueOf(LocalDate.of(invoiceEntity.getYear(), invoiceEntity.getMonth(), 1)));
-    if (command.getPaidDate() != null)
+    if (command.getPaidDate() != null) {
       invoiceEntity.setPaidDate(Date.valueOf(command.getPaidDate()));
-    if (command.getDueDate() != null) invoiceEntity.setDueDate(Date.valueOf(command.getDueDate()));
+    }
+    if (command.getDueDate() != null) {
+      invoiceEntity.setDueDate(Date.valueOf(command.getDueDate()));
+    }
     if (command.getFile() != null) {
       invoiceEntity.setFileName(command.getFile().getFileName());
       invoiceEntity.setFile(command.getFile().getFile());
     }
     invoiceEntity.setLink(command.getLink());
 
-    addDynamicFields(command.getAttributes(), contractEntity, invoiceEntity);
+    addDynamicFields(
+        Objects.requireNonNullElseGet(command.getAttributes(), HashMap::new),
+        contractEntity,
+        invoiceEntity);
 
     return invoiceMapper.mapToDomain(invoiceRepository.save(invoiceEntity));
   }

--- a/budgeteer-persistence/src/test/java/de/adesso/budgeteer/persistence/invoice/InvoiceEntityAdapterTest.java
+++ b/budgeteer-persistence/src/test/java/de/adesso/budgeteer/persistence/invoice/InvoiceEntityAdapterTest.java
@@ -1,0 +1,83 @@
+package de.adesso.budgeteer.persistence.invoice;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.when;
+
+import de.adesso.budgeteer.core.invoice.domain.Invoice;
+import de.adesso.budgeteer.core.invoice.port.out.CreateInvoiceEntityPort;
+import de.adesso.budgeteer.persistence.contract.ContractAdapter;
+import de.adesso.budgeteer.persistence.contract.ContractEntity;
+import de.adesso.budgeteer.persistence.contract.ContractRepository;
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.HashMap;
+import java.util.Optional;
+import org.joda.money.CurrencyUnit;
+import org.joda.money.Money;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InvoiceEntityAdapterTest {
+
+  @Mock private InvoiceRepository invoiceRepository;
+  @Mock private InvoiceMapper invoiceMapper;
+  @Mock private ContractRepository contractRepository;
+  @Mock private ContractAdapter contractAdapter;
+  @InjectMocks private InvoiceEntityAdapter invoiceEntityAdapter;
+
+  @Test
+  void shouldCreateInvoiceWithMinimalValidCreateInvoiceEntityCommand() {
+    var command =
+        new CreateInvoiceEntityPort.CreateInvoiceEntityCommand(
+            1L,
+            "invoiceName",
+            Money.of(CurrencyUnit.EUR, 0),
+            BigDecimal.ZERO,
+            "internalNumber",
+            YearMonth.of(2020, 12),
+            null,
+            null,
+            null,
+            null,
+            null);
+    var contractEntity = new ContractEntity();
+    var invoiceEntity = new InvoiceEntity();
+    invoiceEntity.setContract(contractEntity);
+    invoiceEntity.setName(command.getInvoiceName());
+    invoiceEntity.setInvoiceSum(command.getAmountOwed());
+    invoiceEntity.setInternalNumber(command.getInternalNumber());
+    invoiceEntity.setYear(command.getYearMonth().getYear());
+    invoiceEntity.setMonth(command.getYearMonth().getMonthValue());
+    invoiceEntity.setDate(
+        Date.valueOf(
+            LocalDate.of(
+                command.getYearMonth().getYear(), command.getYearMonth().getMonthValue(), 1)));
+    var expected =
+        new Invoice(
+            2L,
+            command.getContractId(),
+            "contractName",
+            command.getInvoiceName(),
+            command.getAmountOwed(),
+            command.getTaxRate(),
+            command.getInternalNumber(),
+            command.getYearMonth(),
+            command.getPaidDate(),
+            command.getDueDate(),
+            new HashMap<>(),
+            command.getLink(),
+            command.getFile());
+    when(invoiceRepository.save(invoiceEntity)).thenReturn(invoiceEntity);
+    when(invoiceMapper.mapToDomain(invoiceEntity)).thenReturn(expected);
+    when(contractRepository.findById(command.getContractId()))
+        .thenReturn(Optional.of(contractEntity));
+    var result = invoiceEntityAdapter.createInvoiceEntity(command);
+    assertThat(result).isEqualTo(expected);
+  }
+}


### PR DESCRIPTION
A NullPointerException was thrown by
InvoiceEntityAdapter#createInvoiceEntity() when attributes was null due
to a missing check to see if attributes were set.